### PR TITLE
Mass flow meter rework

### DIFF
--- a/includes/config.h
+++ b/includes/config.h
@@ -55,7 +55,6 @@
 // Available Mass Flow Meters
 #define MFM_SFM_3300D 1
 #define MFM_SDP703_02 2
-#define MFM_OMRON_D6F 3
 #define MFM_HONEYWELL_HAF 4
 
 // Defines the type and the range of the mass flow meter

--- a/includes/mass_flow_meter.h
+++ b/includes/mass_flow_meter.h
@@ -35,6 +35,11 @@ void MFM_reset(void);
  */
 void MFM_calibrateZero(void);
 
+/**
+ * Read instant air flow
+ */
+int32_t MFM_read_airflow(void);
+
 extern int32_t mfmLastValue;
 
 #define MASS_FLOW_ERROR_VALUE 999999

--- a/includes/parameters.h
+++ b/includes/parameters.h
@@ -381,6 +381,9 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 0;
 #define PIN_I2C_SDA PB9
 #define PIN_I2C_SCL PB8
 #define MFM_ANALOG_INPUT A3
+#define MFM_POWER_CONTROL PC0
+#define MFM_POWER_OFF LOW
+#define MFM_POWER_ON HIGH
 #endif
 #endif
 


### PR DESCRIPTION
- Removed omron D6F support (never worked)
- more robust flowmeter communication
- fixes #49 
Now return a value greater than MASS_FLOW_ERROR_VALUE when an error while encountered this last value read with reset.
