### PR TITLE
support of power supply mains connection to expander

### DIFF
--- a/includes/battery.h
+++ b/includes/battery.h
@@ -10,44 +10,56 @@
 #include "Arduino.h"
 
 /**
- * Expected voltage in volts when power cord is plugged.
- * Calculated by analogRead(PIN) * 0,0296484375 = 27,6 => 27,6 / 0,0296484375 = 930,9
+ * The divider between real battery voltage and stm32 input is 8.2K-1k resistors
+ * So, the multiplier is 1/(1+8.2)=0.1087
+ * Considering 0.1% precision resistances, multiplier is between 0,108502 and 0,108889
+ * The reference is 3.348V (measured on 53 HW V3 boards)
+ * RawValue = (Vbat*0.1087)*1024/3.348
+ * So, Vbat = RawValue * (3.348/(1024*0.1087))
+ *
+ * 1 bit = 3.348/(1024*0.1087) = 30.07mV .
  */
-#define RAW_VOLTAGE_MAINS 931
+#define RAW_BATTERY_MULTIPLIER 0.0300784843606
+
+/**
+ * Expected voltage in volts when power cord is plugged.
+ * 27,4 V => 27,4 / RAW_BATTERY_MULTIPLIER
+ */
+#define RAW_VOLTAGE_MAINS 907
 
 /**
  * RCM_SW_16
  * Expected voltage in volts when power cord is unplugged.
- * Calculated by analogRead(PIN) * 0,0296484375 = 27 => 27 / 0,0296484375 = 911
+ *  = 27 => 27 / RAW_BATTERY_MULTIPLIER
  */
-#define RAW_VOLTAGE_ON_BATTERY_HIGH 911u
+#define RAW_VOLTAGE_ON_BATTERY_HIGH 897u
 
-// analogRead(PIN) * 0,0296484375 = 0,1 => 0,1 / 0,0296484375 = 3
+// analogRead(PIN) * RAW_BATTERY_MULTIPLIER = 0,1 => 0,1 / RAW_BATTERY_MULTIPLIER = 3
 #define RAW_VOLTAGE_HYSTERESIS 3u
 
 /**
  * RCM_SW_11
- * Calculated by analogRead(PIN) * 0,0296484375 = 24,6 => 24,6 / 0,0296484375 = 829,7
+ *  = 24,6 => 24,6 / RAW_BATTERY_MULTIPLIER
  */
-#define RAW_VOLTAGE_ON_BATTERY 830u
+#define RAW_VOLTAGE_ON_BATTERY 817u
 
 /**
  * RCM_SW_12
- * Calculated by analogRead(PIN) * 0,0296484375 = 24 => 24 / 0,0296484375 = 809,4
+ *  = 24 => 24 / RAW_BATTERY_MULTIPLIER
  */
-#define RAW_VOLTAGE_ON_BATTERY_LOW 809u
+#define RAW_VOLTAGE_ON_BATTERY_LOW 797u
 
 /**
  * Below this value, the machine wont start
- * Calculated by analogRead(PIN) * 0,0296484375 = 22 => 22 / 0,0296484375 = 742
+ *  = 22 => 22 / RAW_BATTERY_MULTIPLIER
  */
-#define RAW_VOLTAGE_ON_BATTERY_NOT_STARTING_THRESHOLD 742u
+#define RAW_VOLTAGE_ON_BATTERY_NOT_STARTING_THRESHOLD 731u
 
 /**
  * Below this value, the machine will stop immediately
- * Calculated by analogRead(PIN) * 0,0296484375 = 20 => 20 / 0,0296484375 = 675
+ *  = 20 => 20 / RAW_BATTERY_MULTIPLIER
  */
-#define RAW_VOLTAGE_ON_BATTERY_STOP_THRESHOLD 675u
+#define RAW_VOLTAGE_ON_BATTERY_STOP_THRESHOLD 664u
 
 /// Number of samples of the moving average
 #define BATTERY_MAX_SAMPLES 20u
@@ -91,6 +103,15 @@ uint32_t getBatteryLevel();
  */
 uint32_t getBatteryLevelX10();
 
+/**
+ * Returns battery level x100 for better accuracy
+ *
+ * @return Battery level in volts x100
+ */
+uint32_t getBatteryLevelX100();
+
 bool isBatteryVeryLow();
 
 bool isBatteryDeepDischarged();
+
+bool isMainsConnected();

--- a/includes/parameters.h
+++ b/includes/parameters.h
@@ -266,6 +266,8 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 0;
 #define PIN_IN_ROW1 PC9
 #define PIN_IN_ROW2 PC10
 #define PIN_IN_ROW3 PC11
+// expander used to read AC status
+#define PIN_IN_MAINS_CONNECTED PB1
 #endif
 
 ///@}

--- a/srcs/battery.cpp
+++ b/srcs/battery.cpp
@@ -22,11 +22,12 @@
 
 // PROGRAM =====================================================================
 
-static uint32_t rawBatterySample[20];      // Array to store battery voltage samples
-static uint32_t batteryCurrentSample = 0;  // Current battery sample index
-static uint32_t batteryTotalSamples = 0;   // Battery total samples
+static uint32_t rawBatterySample[BATTERY_MAX_SAMPLES];  // Array to store battery voltage samples
+static uint32_t batteryCurrentSample = 0;               // Current battery sample index
+static uint32_t batteryTotalSamples = 0;                // Battery total samples
 static uint32_t rawBatteryMeanVoltage = RAW_VOLTAGE_MAINS;  // Mean battery voltage in volts
 static bool isRunningOnBattery = false;
+static bool mainsConnected = false;
 
 void initBattery() {
     for (uint8_t i = 0; i < BATTERY_MAX_SAMPLES; i++) {
@@ -42,14 +43,8 @@ void initBattery() {
 void updateBatterySample() {
     uint16_t rawVout = analogRead(PIN_BATTERY);
 
-    // Substract previous sample
-    batteryTotalSamples = batteryTotalSamples - rawBatterySample[batteryCurrentSample];
-
     // Assign sample from Vout
     rawBatterySample[batteryCurrentSample] = rawVout;
-
-    // Add sample
-    batteryTotalSamples = batteryTotalSamples + rawBatterySample[batteryCurrentSample];
 
     // Increment sample
     batteryCurrentSample++;
@@ -59,38 +54,52 @@ void updateBatterySample() {
         batteryCurrentSample = 0;
     }
 
+    batteryTotalSamples = 0;
+    for (uint8_t i = 0; i < BATTERY_MAX_SAMPLES; i++) {
+        batteryTotalSamples += rawBatterySample[i];
+    }
     // Updates mean voltage
     rawBatteryMeanVoltage = (batteryTotalSamples / BATTERY_MAX_SAMPLES);
 }
 
 void updateBatteryState(uint32_t p_cycleNumber) {
-    if (rawBatteryMeanVoltage < (RAW_VOLTAGE_ON_BATTERY_HIGH - RAW_VOLTAGE_HYSTERESIS)) {
+#if HARDWARE_VERSION == 3
+    pinMode(PIN_IN_MAINS_CONNECTED, INPUT_PULLUP);
+    mainsConnected = (LOW == digitalRead(PIN_IN_MAINS_CONNECTED));
+#else
+    mainsConnected = false;
+#endif
+
+    if (!mainsConnected
+        && (rawBatteryMeanVoltage < (RAW_VOLTAGE_ON_BATTERY_HIGH - RAW_VOLTAGE_HYSTERESIS))) {
         alarmController.detectedAlarm(RCM_SW_16, p_cycleNumber,
                                       (RAW_VOLTAGE_ON_BATTERY_HIGH - RAW_VOLTAGE_HYSTERESIS),
                                       rawBatteryMeanVoltage);
         isRunningOnBattery = true;
-    } else if (rawBatteryMeanVoltage > RAW_VOLTAGE_ON_BATTERY_HIGH) {
+    } else if (mainsConnected || (rawBatteryMeanVoltage > RAW_VOLTAGE_ON_BATTERY_HIGH)) {
         alarmController.notDetectedAlarm(RCM_SW_16);
         isRunningOnBattery = false;
     } else {
         // This is an hysteresis, so do nothing here
     }
 
-    if (rawBatteryMeanVoltage < (RAW_VOLTAGE_ON_BATTERY - RAW_VOLTAGE_HYSTERESIS)) {
+    if (!mainsConnected
+        && (rawBatteryMeanVoltage < (RAW_VOLTAGE_ON_BATTERY - RAW_VOLTAGE_HYSTERESIS))) {
         alarmController.detectedAlarm(RCM_SW_11, p_cycleNumber,
                                       (RAW_VOLTAGE_ON_BATTERY - RAW_VOLTAGE_HYSTERESIS),
                                       rawBatteryMeanVoltage);
-    } else if (rawBatteryMeanVoltage > RAW_VOLTAGE_ON_BATTERY) {
+    } else if (mainsConnected || (rawBatteryMeanVoltage > RAW_VOLTAGE_ON_BATTERY)) {
         alarmController.notDetectedAlarm(RCM_SW_11);
     } else {
         // This is an hysteresis, so do nothing here
     }
 
-    if (rawBatteryMeanVoltage < (RAW_VOLTAGE_ON_BATTERY_LOW - RAW_VOLTAGE_HYSTERESIS)) {
+    if (!mainsConnected
+        && (rawBatteryMeanVoltage < (RAW_VOLTAGE_ON_BATTERY_LOW - RAW_VOLTAGE_HYSTERESIS))) {
         alarmController.detectedAlarm(RCM_SW_12, p_cycleNumber,
                                       (RAW_VOLTAGE_ON_BATTERY_LOW - RAW_VOLTAGE_HYSTERESIS),
                                       rawBatteryMeanVoltage);
-    } else if (rawBatteryMeanVoltage > RAW_VOLTAGE_ON_BATTERY_LOW) {
+    } else if (mainsConnected || (rawBatteryMeanVoltage > RAW_VOLTAGE_ON_BATTERY_LOW)) {
         alarmController.notDetectedAlarm(RCM_SW_12);
     } else {
         // This is an hysteresis, so do nothing here
@@ -103,10 +112,13 @@ void batteryLoop(uint32_t p_cycleNumber) {
 }
 
 // cppcheck-suppress unusedFunction
-uint32_t getBatteryLevel() { return rawBatteryMeanVoltage * 0.0296484375; }
+uint32_t getBatteryLevel() { return rawBatteryMeanVoltage * RAW_BATTERY_MULTIPLIER; }
 
 // cppcheck-suppress unusedFunction
-uint32_t getBatteryLevelX10() { return rawBatteryMeanVoltage * (10.0 * 0.0296484375); }
+uint32_t getBatteryLevelX10() { return rawBatteryMeanVoltage * (10.0 * RAW_BATTERY_MULTIPLIER); }
+
+// cppcheck-suppress unusedFunction
+uint32_t getBatteryLevelX100() { return rawBatteryMeanVoltage * (100.0 * RAW_BATTERY_MULTIPLIER); }
 
 // cppcheck-suppress unusedFunction
 bool isBatteryVeryLow() {
@@ -116,3 +128,6 @@ bool isBatteryVeryLow() {
 bool isBatteryDeepDischarged() {
     return rawBatteryMeanVoltage < RAW_VOLTAGE_ON_BATTERY_STOP_THRESHOLD;
 }
+
+// cppcheck-suppress unusedFunction
+bool isMainsConnected() { return (!isRunningOnBattery); }


### PR DESCRIPTION
- fix battery level with high precision resistors
- update the eol tests

need two extra wires to connect mains to expander connector. When not connected, fallback on the battery level.
- mains connection is immediatly detected
- mains disconnection is not immediatly detected for retro compatibility.  (when blower is running, it took a few seconds for voltage to drop)

![IMG_1473](https://user-images.githubusercontent.com/37228740/98047246-e804fc80-1e2b-11eb-9c89-ef2256b9bb31.JPG)
![IMG_1474](https://user-images.githubusercontent.com/37228740/98047248-e89d9300-1e2b-11eb-9da3-b8e7597e2fd9.JPG)

