### PR TITLE
Remove simulation flag.

### DIFF
--- a/includes/config.h
+++ b/includes/config.h
@@ -26,9 +26,6 @@
  */
 #define DEBUG 3
 
-/// Simulation mode allows to run main controller on a computer
-#define SIMULATION false
-
 /// Defines if the device has a Mass Flow Meter or not
 // Comment out when no sensor
 #define MASS_FLOW_METER_ENABLED

--- a/includes/config.h
+++ b/includes/config.h
@@ -51,4 +51,4 @@
 /// Defines the range of the Mass Flow Meter in SLM (standard liter per minute)
 #define MFM_RANGE 200
 
-//#define DISABLE_BUTTONS
+// #define DISABLE_BUTTONS

--- a/includes/main_controller.h
+++ b/includes/main_controller.h
@@ -14,7 +14,6 @@
 #include "../includes/alarm_controller.h"
 #include "../includes/battery.h"
 #include "../includes/telemetry.h"
-
 #include "../includes/blower.h"
 #include "../includes/config.h"
 #include "../includes/cycle.h"

--- a/includes/main_controller.h
+++ b/includes/main_controller.h
@@ -11,11 +11,9 @@
 
 // Internal
 
-#if !SIMULATION
 #include "../includes/alarm_controller.h"
 #include "../includes/battery.h"
 #include "../includes/telemetry.h"
-#endif
 
 #include "../includes/blower.h"
 #include "../includes/config.h"
@@ -298,7 +296,9 @@ class MainController {
         return m_inspiratoryDurationNextCommand;
     }
     /// Ventilation controller pointer for the next cycle
-    inline const VentilationController* ventilationControllerNextCommand() const { return m_ventilationControllerNextCommand; }
+    inline const VentilationController* ventilationControllerNextCommand() const {
+        return m_ventilationControllerNextCommand;
+    }
 
 
     /// Get the measured peak pressure

--- a/includes/main_controller.h
+++ b/includes/main_controller.h
@@ -143,7 +143,7 @@ class MainController {
     /// Set the inspiratory flow target
     void onTargetInspiratoryFlow(uint16_t p_targetInspiratoryFlow);
 
-    /// Set the inspiration duration 
+    /// Set the inspiration duration
     void onInspiratoryDuration(uint16_t p_inspiratoryDuration);
 
     /// Decrease the desired number of cycles per minute
@@ -252,10 +252,12 @@ class MainController {
     /// Get the value of the max duration of inspiration in ms
     inline const int16_t tiMaxCommand() const { return m_tiMaxCommand; }
     /// get target inspiratory flow in mL/min (used in VC modes)
-    inline const int32_t targetInspiratoryFlowCommand() const { return m_targetInspiratoryFlowCommand; }
+    inline const int32_t targetInspiratoryFlowCommand() const {
+        return m_targetInspiratoryFlowCommand;
+    }
     /// Get duration of inspiration command
     inline const int16_t inspiratoryDurationCommand() const { return m_inspiratoryDurationCommand; }
-    
+
 
     /// Get the desired tidal Volume for the next cycle (used in VC modes)
     inline int16_t tidalVolumeNextCommand() const { return m_tidalVolumeNextCommand; }
@@ -288,13 +290,17 @@ class MainController {
     /// Get the value of the max duration of inspiration in ms for the next cycle
     inline const int16_t tiMaxNextCommand() const { return m_tiMaxNextCommand; }
     /// get target inspiratory flow in mL/min (used in VC modes) for next cycle
-    inline const int32_t targetInspiratoryFlowNextCommand() const { return m_targetInspiratoryFlowNextCommand; }
+    inline const int32_t targetInspiratoryFlowNextCommand() const {
+        return m_targetInspiratoryFlowNextCommand;
+    }
     /// Get duration of inspiration command fo next cycle
-    inline const int16_t inspiratoryDurationNextCommand() const { return m_inspiratoryDurationNextCommand; }
+    inline const int16_t inspiratoryDurationNextCommand() const {
+        return m_inspiratoryDurationNextCommand;
+    }
     /// Ventilation controller pointer for the next cycle
     inline const VentilationController* ventilationControllerNextCommand() const { return m_ventilationControllerNextCommand; }
-    
-    
+
+
     /// Get the measured peak pressure
     inline int16_t peakPressureMeasure() const { return m_peakPressureMeasure; }
     /// Get the measured rebounce peak pressure
@@ -557,56 +563,56 @@ class MainController {
     int32_t m_targetInspiratoryFlowCommand;
     /// inspiratory flow required (used in VC modes) for next cycle
     int32_t m_targetInspiratoryFlowNextCommand;
-    /// Duration of inspiration    
-    int16_t m_inspiratoryDurationCommand;   
+    /// Duration of inspiration
+    int16_t m_inspiratoryDurationCommand;
     /// Duration of inspiration/// Duration of inspiration
     int16_t m_inspiratoryDurationNextCommand;
 
     // Threshold for low inspiratory minute volume alarm
-    int32_t m_lowInspiratoryMinuteVolumeAlarmThresholdCommand; 
+    int32_t m_lowInspiratoryMinuteVolumeAlarmThresholdCommand;
     // Threshold for low inspiratory minute volume alarm for next cycle
     int32_t m_lowInspiratoryMinuteVolumeAlarmThresholdNextCommand;
 
     // Threshold for high inspiratory minute volume alarm
-    int32_t m_highInspiratoryMinuteVolumeAlarmThresholdCommand; 
+    int32_t m_highInspiratoryMinuteVolumeAlarmThresholdCommand;
     // Threshold for high inspiratory minute volume alarm for next cycle
-    int32_t m_highInspiratoryMinuteVolumeAlarmThresholdNextCommand; 
+    int32_t m_highInspiratoryMinuteVolumeAlarmThresholdNextCommand;
 
     // Threshold for low inspiratory minute volume alarm
-    int32_t m_lowExpiratoryMinuteVolumeAlarmThresholdCommand; 
+    int32_t m_lowExpiratoryMinuteVolumeAlarmThresholdCommand;
     // Threshold for low inspiratory minute volume alarm for next cycle
-    int32_t m_lowExpiratoryMinuteVolumeAlarmThresholdNextCommand; 
+    int32_t m_lowExpiratoryMinuteVolumeAlarmThresholdNextCommand;
 
     // Threshold for high inspiratory minute volume alarm
-    int32_t m_highExpiratoryMinuteVolumeAlarmThresholdCommand; 
+    int32_t m_highExpiratoryMinuteVolumeAlarmThresholdCommand;
     // Threshold for high inspiratory minute volume alarm for next cycle
-    int32_t m_highExpiratoryMinuteVolumeAlarmThresholdNextCommand; 
+    int32_t m_highExpiratoryMinuteVolumeAlarmThresholdNextCommand;
 
     // Threshold for low respiratory rate
-    int32_t m_lowRespiratoryRateAlarmThresholdCommand; 
+    int32_t m_lowRespiratoryRateAlarmThresholdCommand;
     // Threshold for low respiratory rate for next cycle
-    int32_t m_lowRespiratoryRateAlarmThresholdNextCommand; 
+    int32_t m_lowRespiratoryRateAlarmThresholdNextCommand;
 
     // Threshold for low respiratory rate
-    int32_t m_highRespiratoryRateAlarmThresholdCommand; 
+    int32_t m_highRespiratoryRateAlarmThresholdCommand;
     // Threshold for low respiratory rate for next cycle
-    int32_t m_highRespiratoryRateAlarmThresholdNextCommand; 
+    int32_t m_highRespiratoryRateAlarmThresholdNextCommand;
 
-    // Threshold for low tidal Volume Alarm 
-    int32_t m_lowTidalVolumeAlarmTresholdCommand; 
+    // Threshold for low tidal Volume Alarm
+    int32_t m_lowTidalVolumeAlarmTresholdCommand;
     // Threshold for low tidal Volume Alarm next cycle
-    int32_t m_lowTidalVolumeAlarmTresholdNextCommand; 
+    int32_t m_lowTidalVolumeAlarmTresholdNextCommand;
 
-    // Threshold for high tidal Volume Alarm 
-    int32_t m_highTidalVolumeAlarmTresholdCommand; 
+    // Threshold for high tidal Volume Alarm
+    int32_t m_highTidalVolumeAlarmTresholdCommand;
     // Threshold for high tidal Volume Alarm next cycle
-    int32_t m_highTidalVolumeAlarmTresholdNextCommand; 
+    int32_t m_highTidalVolumeAlarmTresholdNextCommand;
 
     // Threshold for leak alarm
-    int32_t m_leakAlarmThresholdCommand; 
+    int32_t m_leakAlarmThresholdCommand;
     // Threshold for leak alarm for next cycle
-    int32_t m_leakAlarmThresholdNextCommand; 
-    
+    int32_t m_leakAlarmThresholdNextCommand;
+
 
     /// Volume expired by the patient during the exhalation phase
     int32_t m_expiratoryVolume;

--- a/includes/pc_ac_controller.h
+++ b/includes/pc_ac_controller.h
@@ -17,7 +17,7 @@ class PC_AC_Controller final : public PC_CMV_Controller {
     void exhale() override;
 
     /// List of alarms that must be enabled for this mode
-    struct Alarms enabledAlarms() const {
+    struct Alarms enabledAlarms() const override {
         struct Alarms a = {RCM_SW_1,  RCM_SW_2,  RCM_SW_3,  RCM_SW_4,  RCM_SW_5,  RCM_SW_6,
                            RCM_SW_7,  RCM_SW_8,  RCM_SW_9, 0u,  RCM_SW_11, RCM_SW_12, RCM_SW_14,
                            RCM_SW_15, RCM_SW_16, RCM_SW_18, RCM_SW_19, RCM_SW_20, RCM_SW_21};

--- a/includes/pc_cmv_controller.h
+++ b/includes/pc_cmv_controller.h
@@ -32,7 +32,7 @@ class PC_CMV_Controller : public VentilationController {
     void endCycle() override;
 
     /// List of alarms that must be enabled for this mode
-    struct Alarms enabledAlarms() const {
+    struct Alarms enabledAlarms() const override {
         struct Alarms a = {RCM_SW_1,  RCM_SW_2,  RCM_SW_3,  RCM_SW_4,  RCM_SW_5,  RCM_SW_6,
                            RCM_SW_7,  RCM_SW_8,  RCM_SW_9, 0u, RCM_SW_11, RCM_SW_12, RCM_SW_14,
                            RCM_SW_15, RCM_SW_16, RCM_SW_18, RCM_SW_19, RCM_SW_20, RCM_SW_21};

--- a/includes/pc_vsai_controller.h
+++ b/includes/pc_vsai_controller.h
@@ -32,7 +32,7 @@ class PC_VSAI_Controller final : public VentilationController {
     void endCycle() override;
 
     /// List of alarms that must be enabled for this mode
-    struct Alarms enabledAlarms() const {
+    struct Alarms enabledAlarms() const override {
         struct Alarms a = {RCM_SW_1,  RCM_SW_2,  RCM_SW_3,  RCM_SW_4,  RCM_SW_5,  RCM_SW_6,
                            RCM_SW_7,  RCM_SW_8,  RCM_SW_9, 0u, RCM_SW_11, RCM_SW_12, RCM_SW_14,
                            RCM_SW_15, RCM_SW_16, RCM_SW_18, RCM_SW_19, RCM_SW_20, RCM_SW_21};

--- a/includes/vc_ac_controller.h
+++ b/includes/vc_ac_controller.h
@@ -17,7 +17,7 @@ class VC_AC_Controller final : public VC_CMV_Controller {
     void exhale() override;
 
     /// List of alarms that must be enabled for this mode
-    struct Alarms enabledAlarms() const {
+    struct Alarms enabledAlarms() const override {
         struct Alarms a = {0u,        RCM_SW_2,  RCM_SW_3, RCM_SW_4,  RCM_SW_5,
                            RCM_SW_6,  RCM_SW_7,  RCM_SW_8, RCM_SW_9,  RCM_SW_10,
                            RCM_SW_11, RCM_SW_12, 0u,       RCM_SW_15, RCM_SW_16,

--- a/includes/vc_cmv_controller.h
+++ b/includes/vc_cmv_controller.h
@@ -54,14 +54,10 @@ class VC_CMV_Controller : public VentilationController {
 
     bool m_duringPlateau = true;
 
-    int32_t m_volume;
     /// Current blower speed
     uint16_t m_blowerSpeed;
 
     int32_t m_targetFlowMultiplyBy1000;
-
-    /// Slope of the inspiration open loop (in mmH2O/s)
-    int32_t m_inspiratorySlope;
 
     /// Fast mode at start of expiration
     bool m_expiratoryPidFastMode;
@@ -80,29 +76,18 @@ class VC_CMV_Controller : public VentilationController {
 
     /// Error of the last computation of the PID
     int32_t m_expiratoryPidLastError;
+
     /// Last errors in expiratory PID
     int32_t m_expiratoryPidLastErrors[PC_NUMBER_OF_SAMPLE_DERIVATIVE_MOVING_MEAN];
+
     /// Last error index in expiratory PID
     int32_t m_expiratoryPidLastErrorsIndex;
-
-    /// Error of the last computation of the expiratory PID
-    int32_t m_inspiratoryPidLastError;
-    /// Last errors in inspiratory PID
-    int32_t m_inspiratoryPidLastErrors[PC_NUMBER_OF_SAMPLE_DERIVATIVE_MOVING_MEAN];
-    /// Last error index in inspiratory PID
-    int32_t m_inspiratoryPidLastErrorsIndex;
 
     /// Last flow values
     int32_t m_inspiratoryFlowLastValues[NUMBER_OF_SAMPLE_LAST_VALUES];
 
-    /// Last pressure values
-    int32_t m_inspiratoryPressureLastValues[NUMBER_OF_SAMPLE_LAST_VALUES];
-
     /// Last flow index
     int32_t m_inspiratoryFlowLastValuesIndex;
-
-    /// Last pressure index
-    int32_t m_inspiratoryPressureLastValuesIndex;
 
     /// Max flow during inspiration
     int32_t m_maxInspiratoryFlow;

--- a/includes/vc_cmv_controller.h
+++ b/includes/vc_cmv_controller.h
@@ -32,7 +32,7 @@ class VC_CMV_Controller : public VentilationController {
     void endCycle() override;
 
     /// List of alarms that must be enabled for this mode
-    struct Alarms enabledAlarms() const {
+    struct Alarms enabledAlarms() const override {
         struct Alarms a = {0u,        RCM_SW_2,  RCM_SW_3,  0u,  0u,
                            0u,  RCM_SW_7, 0u, 0u, RCM_SW_10, RCM_SW_11, RCM_SW_12, 0u,
                            RCM_SW_15, RCM_SW_16, RCM_SW_18, RCM_SW_19, 0u, 0u};

--- a/srcs/alarm_controller.cpp
+++ b/srcs/alarm_controller.cpp
@@ -153,7 +153,7 @@ AlarmController::AlarmController()
           Alarm(AlarmPriority::ALARM_HIGH, RCM_SW_21, 3u),
         }),
 
-          
+
       m_tick(0u),
       m_unsnooze(true),
       m_pressure(0u),

--- a/srcs/end_of_line_test.cpp
+++ b/srcs/end_of_line_test.cpp
@@ -224,7 +224,8 @@ void millisecondTimerEOL(void)
             eolstep = TEST_BAT_DEAD;
         }
     } else if (eolstep == CONNECT_MAINS) {
-        // Ask the operator to reconnect the machine and wait for a voltage raise of 0.4 V (or direct info from supply)
+        // Ask the operator to reconnect the machine and wait for a voltage raise of 0.4 V
+        // (or direct info from supply)
         batlevel = getBatteryLevelX100();
 
         (void)snprintf(eolScreenBuffer, EOLSCREENSIZE, "Test Vbat\nConnecter 220V...\nV=%02d.%02d",
@@ -318,8 +319,9 @@ void millisecondTimerEOL(void)
     } else if (eolstep == CHECK_UI_SCREEN) {
         // Ask the operator to activate the trigger on the UI screen. It allows to test
         // communication with the UI, and tactile function of the UI.
-        
-        (void)snprintf(eolScreenBuffer, EOLSCREENSIZE, "Changer mode\nde ventilation\nSur ecran ta");
+
+        (void)snprintf(eolScreenBuffer, EOLSCREENSIZE,
+            "Changer mode\nde ventilation\nSur ecran ta");
 
         // Check serial from the UI
         serialControlLoop();

--- a/srcs/keyboard.cpp
+++ b/srcs/keyboard.cpp
@@ -15,7 +15,6 @@
 #include "../includes/keyboard.h"
 
 // External
-#include "../includes/config.h"
 #include <OneButton.h>
 
 // Internal

--- a/srcs/main_controller.cpp
+++ b/srcs/main_controller.cpp
@@ -930,8 +930,8 @@ void MainController::onTiMaxSet(uint16_t p_tiMax) {
 void MainController::onLowInspiratoryMinuteVolumeAlarmThresholdSet(
     uint16_t p_lowInspiratoryMinuteVolumeAlarmThreshold) {
     // CONST_MIN_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD might not be equal to 0
-    // cppcheck-suppress unsignedPositive ;
     if (p_lowInspiratoryMinuteVolumeAlarmThreshold
+            // cppcheck-suppress unsignedPositive ;
             >= CONST_MIN_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD
         && p_lowInspiratoryMinuteVolumeAlarmThreshold
                <= CONST_MAX_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD) {
@@ -962,8 +962,8 @@ void MainController::onHighInspiratoryMinuteVolumeAlarmThresholdSet(
 void MainController::onLowExpiratoryMinuteVolumeAlarmThresholdSet(
     uint16_t p_lowExpiratoryMinuteVolumeAlarmThreshold) {
     // CONST_MIN_LOW_EXPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD might not be equal to 0
-    // cppcheck-suppress unsignedPositive ;
     if (p_lowExpiratoryMinuteVolumeAlarmThreshold
+            // cppcheck-suppress unsignedPositive ;
             >= CONST_MIN_LOW_EXPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD
         && p_lowExpiratoryMinuteVolumeAlarmThreshold
                <= CONST_MAX_LOW_EXPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD) {

--- a/srcs/main_controller.cpp
+++ b/srcs/main_controller.cpp
@@ -164,7 +164,6 @@ void MainController::setup() {
 }
 
 void MainController::initRespiratoryCycle() {
-
     Serial.print(m_expiratoryVolume);
     Serial.print(",");
     Serial.println(m_tidalVolumeMeasure);
@@ -425,7 +424,6 @@ void MainController::updateExpiratoryFlow(int32_t p_currentExpiratoryFlow) {
 
 // cppcheck-suppress unusedFunction
 void MainController::updateFakeExpiratoryFlow() {
-
     // get section in mm2 x 100
     int32_t A2MultiplyBy100 = expiratoryValve.getSectionBigHoseX100();
     int32_t A1MultiplyBy100 = 7853;

--- a/srcs/main_controller.cpp
+++ b/srcs/main_controller.cpp
@@ -483,21 +483,16 @@ void MainController::executeCommands() {
     if (m_pressure > ALARM_THRESHOLD_MAX_PRESSURE) {
         inspiratoryValve.close();
         expiratoryValve.open();
-#if !SIMULATION
         alarmController.detectedAlarm(RCM_SW_18, m_cycleNb, ALARM_THRESHOLD_MAX_PRESSURE,
                                       m_pressure);
-#endif
     } else {
-#if !SIMULATION
         alarmController.notDetectedAlarm(RCM_SW_18);
-#endif
     }
     inspiratoryValve.execute();
     expiratoryValve.execute();
 }
 
 void MainController::checkCycleAlarm() {
-#if !SIMULATION
     // RCM-SW-1 + RCM-SW-14: check if plateau is reached
     int16_t minPlateauBeforeAlarm =
         (m_plateauPressureCommand * (100 - ALARM_THRESHOLD_DIFFERENCE_PERCENT)) / 100;
@@ -590,8 +585,6 @@ void MainController::checkCycleAlarm() {
         alarmController.notDetectedAlarm(RCM_SW_20);
         alarmController.notDetectedAlarm(RCM_SW_21);
     }
-
-#endif
 }
 
 void MainController::reachSafetyPosition() {
@@ -601,7 +594,6 @@ void MainController::reachSafetyPosition() {
 }
 
 void MainController::sendStopMessageToUi() {
-#if !SIMULATION
     sendStoppedMessage(
         mmH2OtoCmH2O(m_peakPressureNextCommand), mmH2OtoCmH2O(m_plateauPressureNextCommand),
         mmH2OtoCmH2O(m_peepNextCommand), m_cyclesPerMinuteNextCommand, m_expiratoryTermNextCommand,
@@ -618,7 +610,6 @@ void MainController::sendStopMessageToUi() {
         m_plateauDurationNextCommand, 0u,
         static_cast<uint8_t>(m_targetInspiratoryFlowNextCommand / 1000),
         m_inspiratoryDurationNextCommand);
-#endif
 }
 
 void MainController::stop(uint32_t p_currentMillis) {
@@ -628,7 +619,6 @@ void MainController::stop(uint32_t p_currentMillis) {
     reachSafetyPosition();
     m_lastEndOfRespirationDateMs = p_currentMillis;
 
-#if !SIMULATION
     // Stop alarms related to breathing cycle
     alarmController.notDetectedAlarm(RCM_SW_1);
     alarmController.notDetectedAlarm(RCM_SW_2);
@@ -646,11 +636,9 @@ void MainController::stop(uint32_t p_currentMillis) {
     alarmController.notDetectedAlarm(RCM_SW_20);
     alarmController.notDetectedAlarm(RCM_SW_21);
     digitalWrite(PIN_LED_START, LED_START_INACTIVE);
-#endif
 }
 
 void MainController::sendMachineState() {
-#if !SIMULATION
     // Send the next command, because command has not been updated yet (will be at the beginning of
     // the next cycle)
     sendMachineStateSnapshot(
@@ -672,7 +660,6 @@ void MainController::sendMachineState() {
         m_plateauDurationNextCommand, 0u,
         static_cast<uint8_t>(m_targetInspiratoryFlowNextCommand / 1000),
         m_inspiratoryDurationNextCommand);
-#endif
 }
 
 void MainController::onVentilationModeSet(uint16_t p_ventilationControllerMode) {
@@ -682,10 +669,8 @@ void MainController::onVentilationModeSet(uint16_t p_ventilationControllerMode) 
         m_ventilationControllerNextCommand =
             m_ventilationControllersTable[m_ventilationControllerMode];
     }
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(1, m_ventilationControllerMode);
-#endif
 }
 
 void MainController::onCycleDecrease() {
@@ -696,10 +681,8 @@ void MainController::onCycleDecrease() {
     if (m_cyclesPerMinuteNextCommand < CONST_MIN_CYCLE) {
         m_cyclesPerMinuteNextCommand = CONST_MIN_CYCLE;
     }
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(4, m_cyclesPerMinuteNextCommand);
-#endif
 }
 
 void MainController::onCycleIncrease() {
@@ -711,10 +694,8 @@ void MainController::onCycleIncrease() {
         m_cyclesPerMinuteNextCommand = CONST_MAX_CYCLE;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(4, m_cyclesPerMinuteNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -727,10 +708,8 @@ void MainController::onCycleSet(uint16_t p_cpm) {
         m_cyclesPerMinuteNextCommand = p_cpm;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(4, m_cyclesPerMinuteNextCommand);
-#endif
 }
 
 void MainController::onPeepPressureDecrease() {
@@ -742,10 +721,8 @@ void MainController::onPeepPressureDecrease() {
         // Do nothing
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(3, m_peepNextCommand);
-#endif
 }
 
 void MainController::onPeepPressureIncrease() {
@@ -760,10 +737,8 @@ void MainController::onPeepPressureIncrease() {
         m_peepNextCommand = CONST_MAX_PEEP_PRESSURE;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(3, m_peepNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -777,10 +752,8 @@ void MainController::onPeepSet(int16_t p_peep) {
         m_peepNextCommand = p_peep;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(3, m_peepNextCommand);
-#endif
 }
 
 void MainController::onPlateauPressureDecrease() {
@@ -794,10 +767,8 @@ void MainController::onPlateauPressureDecrease() {
         m_plateauPressureNextCommand = CONST_MIN_PLATEAU_PRESSURE;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(2, m_plateauPressureNextCommand);
-#endif
 }
 
 void MainController::onPlateauPressureIncrease() {
@@ -808,10 +779,8 @@ void MainController::onPlateauPressureIncrease() {
     m_plateauPressureNextCommand =
         min(m_plateauPressureNextCommand, static_cast<int16_t>(CONST_MAX_PLATEAU_PRESSURE));
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(2, m_plateauPressureNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -824,10 +793,8 @@ void MainController::onPlateauPressureSet(int16_t p_plateauPressure) {
         m_plateauPressureNextCommand = p_plateauPressure;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(2, m_plateauPressureNextCommand);
-#endif
 }
 
 void MainController::onPeakPressureDecrease() {
@@ -886,10 +853,8 @@ void MainController::onExpiratoryTermSet(uint16_t p_expiratoryTerm) {
         m_expiratoryTermNextCommand = p_expiratoryTerm;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(5, m_expiratoryTermNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -897,10 +862,8 @@ void MainController::onTriggerModeEnabledSet(uint16_t p_triggerEnabled) {
     if ((p_triggerEnabled == 0u) || (p_triggerEnabled == 1u)) {
         m_triggerModeEnabledNextCommand = p_triggerEnabled;
     }
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(6, m_triggerModeEnabledNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -914,10 +877,8 @@ void MainController::onTriggerOffsetSet(uint16_t p_triggerOffset) {
         m_pressureTriggerOffsetNextCommand = p_triggerOffset;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(7, m_pressureTriggerOffsetNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -927,10 +888,8 @@ void MainController::onInspiratoryTriggerFlowSet(uint16_t p_inspiratoryTriggerFl
         m_inspiratoryTriggerFlowNextCommand = p_inspiratoryTriggerFlow;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(10, m_inspiratoryTriggerFlowNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -940,10 +899,8 @@ void MainController::onExpiratoryTriggerFlowSet(uint16_t p_expiratoryTriggerFlow
         m_expiratoryTriggerFlowNextCommand = p_expiratoryTriggerFlow;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(11, m_expiratoryTriggerFlowNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -953,10 +910,8 @@ void MainController::onTiMinSet(uint16_t p_tiMin) {
         m_tiMinNextCommand = p_tiMin;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(12, m_tiMinNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -966,10 +921,8 @@ void MainController::onTiMaxSet(uint16_t p_tiMax) {
         m_tiMaxNextCommand = p_tiMax;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(13, m_tiMaxNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -984,10 +937,8 @@ void MainController::onLowInspiratoryMinuteVolumeAlarmThresholdSet(
             1000 * (int32_t)p_lowInspiratoryMinuteVolumeAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(14, m_lowInspiratoryMinuteVolumeAlarmThresholdNextCommand / 1000);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1001,10 +952,8 @@ void MainController::onHighInspiratoryMinuteVolumeAlarmThresholdSet(
             1000 * (int32_t)p_highInspiratoryMinuteVolumeAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(15, m_highInspiratoryMinuteVolumeAlarmThresholdNextCommand / 1000);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1018,10 +967,8 @@ void MainController::onLowExpiratoryMinuteVolumeAlarmThresholdSet(
             1000 * (int32_t)p_lowExpiratoryMinuteVolumeAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(16, m_lowExpiratoryMinuteVolumeAlarmThresholdNextCommand / 1000);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1035,10 +982,8 @@ void MainController::onHighExpiratoryMinuteVolumeAlarmThresholdSet(
             1000 * (int32_t)p_highExpiratoryMinuteVolumeAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(17, m_highExpiratoryMinuteVolumeAlarmThresholdNextCommand / 1000);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1049,10 +994,8 @@ void MainController::onlowRespiratoryRateAlarmThresholdSet(
         m_lowRespiratoryRateAlarmThresholdNextCommand = p_lowRespiratoryRateAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(18, m_lowRespiratoryRateAlarmThresholdNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1063,10 +1006,8 @@ void MainController::onhighRespiratoryRateAlarmThresholdSet(
         m_highRespiratoryRateAlarmThresholdNextCommand = p_highRespiratoryRateAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(19, m_highRespiratoryRateAlarmThresholdNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1075,10 +1016,8 @@ void MainController::onTargetTidalVolumeSet(uint16_t p_targetTidalVolume) {
         && p_targetTidalVolume <= CONST_MAX_TIDAL_VOLUME) {
         m_tidalVolumeNextCommand = p_targetTidalVolume;
     }
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(20, m_tidalVolumeNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1088,10 +1027,8 @@ void MainController::onLowTidalVolumeAlarmTresholdSet(uint16_t p_lowTidalVolumeA
         m_lowTidalVolumeAlarmTresholdNextCommand = p_lowTidalVolumeAlarmTreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(21, m_lowTidalVolumeAlarmTresholdNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1101,10 +1038,8 @@ void MainController::onHighTidalVolumeAlarmTresholdSet(uint16_t p_highTidalVolum
         m_highTidalVolumeAlarmTresholdNextCommand = p_highTidalVolumeAlarmTreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(22, m_highTidalVolumeAlarmTresholdNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1114,10 +1049,8 @@ void MainController::onPlateauDurationSet(uint16_t p_plateauDuration) {
         m_plateauDurationNextCommand = p_plateauDuration;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(23, m_plateauDurationNextCommand);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1128,10 +1061,8 @@ void MainController::onLeakAlarmThresholdSet(uint16_t p_leakAlarmThreshold) {
         m_leakAlarmThresholdNextCommand = 10 * p_leakAlarmThreshold;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(24, m_leakAlarmThresholdNextCommand / 10);
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1142,10 +1073,8 @@ void MainController::onTargetInspiratoryFlow(uint16_t p_targetInspiratoryFlow) {
         m_targetInspiratoryFlowNextCommand = temporaryValue;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(25, static_cast<uint16_t>(m_targetInspiratoryFlowNextCommand / 1000));
-#endif
 }
 
 // cppcheck-suppress unusedFunction
@@ -1155,8 +1084,6 @@ void MainController::onInspiratoryDuration(uint16_t p_inspiratoryDuration) {
         m_inspiratoryDurationNextCommand = p_inspiratoryDuration;
     }
 
-#if !SIMULATION
     // Send acknowledgment to the UI
     sendControlAck(26, m_inspiratoryDurationNextCommand);
-#endif
 }

--- a/srcs/main_controller.cpp
+++ b/srcs/main_controller.cpp
@@ -200,8 +200,6 @@ void MainController::initRespiratoryCycle() {
         m_lowExpiratoryMinuteVolumeAlarmThresholdNextCommand;
     m_highExpiratoryMinuteVolumeAlarmThresholdCommand =
         m_highExpiratoryMinuteVolumeAlarmThresholdNextCommand;
-    m_highExpiratoryMinuteVolumeAlarmThresholdCommand =
-        m_highExpiratoryMinuteVolumeAlarmThresholdNextCommand;
     m_lowRespiratoryRateAlarmThresholdCommand = m_lowRespiratoryRateAlarmThresholdNextCommand;
     m_highTidalVolumeAlarmTresholdCommand = m_highTidalVolumeAlarmTresholdNextCommand;
     m_leakAlarmThresholdCommand = m_leakAlarmThresholdNextCommand;
@@ -881,6 +879,8 @@ void MainController::onTriggerOffsetSet(uint16_t p_triggerOffset) {
 
 // cppcheck-suppress unusedFunction
 void MainController::onInspiratoryTriggerFlowSet(uint16_t p_inspiratoryTriggerFlow) {
+    // CONST_MIN_INSPIRATORY_TRIGGER_FLOW might not be equal to 0
+    // cppcheck-suppress unsignedPositive ;
     if (p_inspiratoryTriggerFlow >= CONST_MIN_INSPIRATORY_TRIGGER_FLOW
         && p_inspiratoryTriggerFlow <= CONST_MAX_INSPIRATORY_TRIGGER_FLOW) {
         m_inspiratoryTriggerFlowNextCommand = p_inspiratoryTriggerFlow;
@@ -892,6 +892,8 @@ void MainController::onInspiratoryTriggerFlowSet(uint16_t p_inspiratoryTriggerFl
 
 // cppcheck-suppress unusedFunction
 void MainController::onExpiratoryTriggerFlowSet(uint16_t p_expiratoryTriggerFlow) {
+    // CONST_MIN_EXPIRATORY_TRIGGER_FLOW might not be equal to 0
+    // cppcheck-suppress unsignedPositive ;
     if (p_expiratoryTriggerFlow >= CONST_MIN_EXPIRATORY_TRIGGER_FLOW
         && p_expiratoryTriggerFlow <= CONST_MAX_EXPIRATORY_TRIGGER_FLOW) {
         m_expiratoryTriggerFlowNextCommand = p_expiratoryTriggerFlow;
@@ -927,6 +929,8 @@ void MainController::onTiMaxSet(uint16_t p_tiMax) {
 
 void MainController::onLowInspiratoryMinuteVolumeAlarmThresholdSet(
     uint16_t p_lowInspiratoryMinuteVolumeAlarmThreshold) {
+    // CONST_MIN_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD might not be equal to 0
+    // cppcheck-suppress unsignedPositive ;
     if (p_lowInspiratoryMinuteVolumeAlarmThreshold
             >= CONST_MIN_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD
         && p_lowInspiratoryMinuteVolumeAlarmThreshold
@@ -957,6 +961,8 @@ void MainController::onHighInspiratoryMinuteVolumeAlarmThresholdSet(
 // cppcheck-suppress unusedFunction
 void MainController::onLowExpiratoryMinuteVolumeAlarmThresholdSet(
     uint16_t p_lowExpiratoryMinuteVolumeAlarmThreshold) {
+    // CONST_MIN_LOW_EXPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD might not be equal to 0
+    // cppcheck-suppress unsignedPositive ;
     if (p_lowExpiratoryMinuteVolumeAlarmThreshold
             >= CONST_MIN_LOW_EXPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD
         && p_lowExpiratoryMinuteVolumeAlarmThreshold
@@ -1020,6 +1026,8 @@ void MainController::onTargetTidalVolumeSet(uint16_t p_targetTidalVolume) {
 
 // cppcheck-suppress unusedFunction
 void MainController::onLowTidalVolumeAlarmTresholdSet(uint16_t p_lowTidalVolumeAlarmTreshold) {
+    // CONST_MIN_LOW_TIDAL_VOLUME_ALARM_THRESHOLD might not be equal to 0
+    // cppcheck-suppress unsignedPositive ;
     if (p_lowTidalVolumeAlarmTreshold >= CONST_MIN_LOW_TIDAL_VOLUME_ALARM_THRESHOLD
         && p_lowTidalVolumeAlarmTreshold <= CONST_MAX_LOW_TIDAL_VOLUME_ALARM_THRESHOLD) {
         m_lowTidalVolumeAlarmTresholdNextCommand = p_lowTidalVolumeAlarmTreshold;
@@ -1042,6 +1050,8 @@ void MainController::onHighTidalVolumeAlarmTresholdSet(uint16_t p_highTidalVolum
 
 // cppcheck-suppress unusedFunction
 void MainController::onPlateauDurationSet(uint16_t p_plateauDuration) {
+    // CONST_MIN_PLATEAU_DURATION might not be equal to 0
+    // cppcheck-suppress unsignedPositive ;
     if (p_plateauDuration >= CONST_MIN_PLATEAU_DURATION
         && p_plateauDuration <= CONST_MAX_PLATEAU_DURATION) {
         m_plateauDurationNextCommand = p_plateauDuration;

--- a/srcs/main_controller.cpp
+++ b/srcs/main_controller.cpp
@@ -926,7 +926,6 @@ void MainController::onTiMaxSet(uint16_t p_tiMax) {
 }
 
 // cppcheck-suppress unusedFunction
-
 void MainController::onLowInspiratoryMinuteVolumeAlarmThresholdSet(
     uint16_t p_lowInspiratoryMinuteVolumeAlarmThreshold) {
     // CONST_MIN_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD might not be equal to 0
@@ -936,6 +935,7 @@ void MainController::onLowInspiratoryMinuteVolumeAlarmThresholdSet(
         && p_lowInspiratoryMinuteVolumeAlarmThreshold
                <= CONST_MAX_LOW_INSPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD) {
         m_lowInspiratoryMinuteVolumeAlarmThresholdNextCommand =
+            // cppcheck-suppress cert-INT31-c ;
             1000 * (int32_t)p_lowInspiratoryMinuteVolumeAlarmThreshold;
     }
 
@@ -968,6 +968,7 @@ void MainController::onLowExpiratoryMinuteVolumeAlarmThresholdSet(
         && p_lowExpiratoryMinuteVolumeAlarmThreshold
                <= CONST_MAX_LOW_EXPIRATORY_MINUTE_VOLUME_ALARM_THRESHOLD) {
         m_lowExpiratoryMinuteVolumeAlarmThresholdNextCommand =
+            // cppcheck-suppress cert-INT31-c ;
             1000 * (int32_t)p_lowExpiratoryMinuteVolumeAlarmThreshold;
     }
 

--- a/srcs/pressure_utl.cpp
+++ b/srcs/pressure_utl.cpp
@@ -31,13 +31,13 @@ static const int32_t RAW_PRESSURE_FILTER_DIVIDER = 5;
 //
 // There is a voltage divider in between Vout and Vadc
 // Vadc = 68/83 Vout
-// 
+//
 // With current ADC (12 bits), and mean Vref=3.348V:
 // Vadc = 3.348 * RawAdc/4096 = 0,000817382 * RawAdc
-// 
+//
 // Vout = 83/68 * 0,000817382 * RawAdc
 // Vout = 0,000997686 * RawAdc
-// 
+//
 // Put it together:
 // P(mmH20) = 1133((0,000997686 * RawAdc)/5.05) - 45
 // P(mmH20) = 0,223837466 * RawAdc - 45

--- a/srcs/vc_cmv_controller.cpp
+++ b/srcs/vc_cmv_controller.cpp
@@ -110,7 +110,6 @@ void VC_CMV_Controller::inhale() {
     if (mainController.tick()
         < mainController.ticksPerInhalation()
               - mainController.plateauDurationCommand() / MAIN_CONTROLLER_COMPUTE_PERIOD_MS) {
-
         int32_t flow = mainController.inspiratoryFlow();
         int32_t blowerPressure = blower.getBlowerPressure(flow);
         int32_t patientPressure = mainController.pressure();

--- a/srcs/vc_cmv_controller.cpp
+++ b/srcs/vc_cmv_controller.cpp
@@ -45,6 +45,7 @@ VC_CMV_Controller::VC_CMV_Controller() {
     m_inspiratoryPidIntegral = 0;
     m_expiratoryPidLastError = 0;
     m_maxInspiratoryFlow = 0;
+    m_targetFlowMultiplyBy1000 = 0;
 }
 
 void VC_CMV_Controller::setup() {
@@ -53,7 +54,6 @@ void VC_CMV_Controller::setup() {
 
 void VC_CMV_Controller::initCycle() {
     m_maxInspiratoryFlow = 0;
-    m_volume = 0;
     m_expiratoryValveLastAperture = expiratoryValve.maxAperture();
     // Reset PID values
     m_expiratoryPidIntegral = 0;


### PR DESCRIPTION
We added the following flag for simulation purpose. After some consideration,
we think we don't really need this flag anymore.
All the work about simulation will be done in another repository. It will be
based on the current firmware and all code with I/O will be overloaded in the
simulator repository.